### PR TITLE
Fix CrashTracker Path import and Embryo db_path

### DIFF
--- a/crash_tracker.py
+++ b/crash_tracker.py
@@ -4,6 +4,7 @@ import os
 import json
 import time
 import logging
+from pathlib import Path
 from colorama import Fore, Style
 
 logger = logging.getLogger(__name__)

--- a/genesis_embryo_core.py
+++ b/genesis_embryo_core.py
@@ -345,6 +345,8 @@ class Embryo:
         # Config, modes, args
         self.cfg = config
         self.launch_args = launch_args or argparse.Namespace()
+        # persist DB location for serialization/deepcopy
+        self.db_path = db_path
 
             # Crash tracker
         self.CrashTracker = CrashTracker()


### PR DESCRIPTION
## Summary
- fix missing `Path` import in `crash_tracker.py`
- store `db_path` inside `Embryo` so deepcopy and serialization work - broke during reflections


